### PR TITLE
Adding default type, tool_id, and tool_option_id validation

### DIFF
--- a/pbcommand/cli/examples/dev_app.py
+++ b/pbcommand/cli/examples/dev_app.py
@@ -15,10 +15,10 @@ log = logging.getLogger(__name__)
 
 __version__ = '0.2.0'
 
-# Used for the tool contract id. Must have the form {namespace}.tools.{name}
+# Used for the tool contract id. Must have the form {namespace}.tasks.{name}
 # to prevent namespace collisions. For python tools, the namespace should be
 # the python package name.
-TOOL_ID = "pbcommand.tools.dev_app"
+TOOL_ID = "pbcommand.tasks.dev_app"
 
 
 def add_args_and_options(p):

--- a/pbcommand/cli/examples/dev_mixed_app.py
+++ b/pbcommand/cli/examples/dev_mixed_app.py
@@ -22,7 +22,7 @@ from pbcommand.utils import setup_log
 
 log = logging.getLogger(__name__)
 
-TOOL_ID = "pbcommand.tools.dev_mixed_app"
+TOOL_ID = "pbcommand.tasks.dev_mixed_app"
 __version__ = "0.2.0"
 
 

--- a/pbcommand/cli/examples/dev_simple_app.py
+++ b/pbcommand/cli/examples/dev_simple_app.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 __version__ = '0.1.1'
 
-TOOL_ID = "pbcommand.tools.dev_app_simple"
+TOOL_ID = "pbcommand.tasks.dev_app_simple"
 
 try:
     from pbcore.io import FastaWriter, FastaReader


### PR DESCRIPTION
Updated contract_tool_id in three of the example apps to conform to _.tasks._
id requirement for pbsmrtpipe tasks.
