### PR TITLE
Removed None option from tool contract option resolver

### DIFF
--- a/pbcommand/cli/resolver.py
+++ b/pbcommand/cli/resolver.py
@@ -42,7 +42,7 @@ def _resolve_options(tool_contract, tool_options):
             exp_type = option['properties'][optid]['type']
             value = tool_options.get(optid, option['properties'][optid]['default'])
 
-            if (not isinstance(value, type_map[exp_type]) and value is not None):
+            if not isinstance(value, type_map[exp_type]):
                 raise ToolContractError("Incompatible option types. Supplied "
                                         "{i}. Expected {t}".format(
                                             i=type(value),


### PR DESCRIPTION
If it is None, the tool contract should fail anyway.
