### PR TITLE
Support for passing and gathering arbitrary statistics in the report model

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 2, 13)
+VERSION = (0, 2, 14)
 
 
 def get_version():

--- a/pbcommand/models/report.py
+++ b/pbcommand/models/report.py
@@ -3,6 +3,7 @@
 
 Author: Johann Miller and Michael Kocher
 """
+import warnings
 import abc
 import logging
 import json
@@ -650,3 +651,20 @@ class Report(BaseReportElement):
         with open(file_name, 'w') as f:
             f.write(self.to_json())
         log.info("Wrote report {r}".format(r=file_name))
+
+    @staticmethod
+    def from_simple_dict(report_id, raw_d, namespace):
+        """
+        Generate a Report with populated attributes, starting from a flat
+        dictionary (without namespace).
+        """
+        attributes = []
+        for k, v in raw_d.items():
+            ns = "_".join([namespace, k.lower()])
+            # These can't be none for some reason
+            if v is not None:
+                a = Attribute(ns, v, name=k)
+                attributes.append(a)
+            else:
+                warnings.warn("skipping null entry {k}->{v}".format(k=k, v=v))
+        return Report(report_id, attributes=attributes)

--- a/tests/test_models_report.py
+++ b/tests/test_models_report.py
@@ -1,0 +1,24 @@
+
+import unittest
+import json
+
+from pbcommand.models.report import Report
+
+
+class TestReportModel(unittest.TestCase):
+
+    def test_from_simple_dict(self):
+        r = Report.from_simple_dict("pbcommand_test", {"n_reads": 50},
+                                    "pbcommand")
+        json_dict = json.loads(r.to_json())
+        self.assertEqual(json_dict['attributes'], [
+            {
+                "id": "pbcommand_test.pbcommand_n_reads",
+                "name": "n_reads",
+                "value": 50
+            },
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_models_report.py
+++ b/tests/test_models_report.py
@@ -19,6 +19,18 @@ class TestReportModel(unittest.TestCase):
             },
         ])
 
+    def test_merge(self):
+        r = Report.merge([
+            Report.from_simple_dict("pbcommand_test",
+                                    {"n_reads": 50, "n_zmws": 10},
+                                    "pbcommand"),
+            Report.from_simple_dict("pbcommand_test",
+                                    {"n_reads": 250, "n_zmws": 50},
+                                    "pbcommand")])
+        attr = {a.id: a.value for a in r.attributes}
+        self.assertEqual(attr['pbcommand_n_reads'], 300)
+        self.assertEqual(attr['pbcommand_n_zmws'], 60)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Basically just your gist code refactored into static methods.  This was enough to replace my arbitrary json model with the report in pbtranscript and pbsmrtpipe (separate pull request forthcoming).
