### PR TITLE
Add table and column merging

### DIFF
--- a/tests/data/example-reports/laa_report1.json
+++ b/tests/data/example-reports/laa_report1.json
@@ -1,0 +1,51 @@
+{
+    "_changelist": "UNKNOWN", 
+    "_version": "0.2.14", 
+    "attributes": [], 
+    "dataset_uuids": [], 
+    "id": "pblaa_tasks_laa", 
+    "plotGroups": [], 
+    "tables": [
+        {
+            "columns": [
+                {
+                    "header": "BarcodeName", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.barcodename", 
+                    "values": ["Barcode1", "Barcode2"]
+                }, 
+                {
+                    "header": "FastaName", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.fastaname", 
+                    "values": ["BarcodeFasta1", "BarcodeFasta2"]
+                }, 
+                {
+                    "header": "CoarseCluster", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.coarsecluster", 
+                    "values": [1, 2]
+                }, 
+                {
+                    "header": "Phase", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.phase", 
+                    "values": [1, 2]
+                }, 
+                {
+                    "header": "TotalCoverage", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.totalcoverage", 
+                    "values": [1, 2]
+                }, 
+                {
+                    "header": "SequenceLength", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.sequencelength", 
+                    "values": [1, 2]
+                }, 
+                {
+                    "header": "PredictedAccuracy", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.predictedaccuracy", 
+                    "values": [1, 2]
+                }
+            ], 
+            "id": "pblaa_tasks_laa.pblaa_result_table", 
+            "title": "Pblaa Results By Barcode"
+        }
+    ]
+}

--- a/tests/data/example-reports/laa_report2.json
+++ b/tests/data/example-reports/laa_report2.json
@@ -1,0 +1,51 @@
+{
+    "_changelist": "UNKNOWN", 
+    "_version": "0.2.14", 
+    "attributes": [], 
+    "dataset_uuids": [], 
+    "id": "pblaa_tasks_laa", 
+    "plotGroups": [], 
+    "tables": [
+        {
+            "columns": [
+                {
+                    "header": "BarcodeName", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.barcodename", 
+                    "values": ["Barcode4", "Barcode3"]
+                }, 
+                {
+                    "header": "FastaName", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.fastaname", 
+                    "values": ["BarcodeFasta4", "BarcodeFasta3"]
+                }, 
+                {
+                    "header": "CoarseCluster", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.coarsecluster", 
+                    "values": [4, 3]
+                }, 
+                {
+                    "header": "Phase", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.phase", 
+                    "values": [4, 3]
+                }, 
+                {
+                    "header": "TotalCoverage", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.totalcoverage", 
+                    "values": [4, 3]
+                }, 
+                {
+                    "header": "SequenceLength", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.sequencelength", 
+                    "values": [4, 3]
+                }, 
+                {
+                    "header": "PredictedAccuracy", 
+                    "id": "pblaa_tasks_laa.pblaa_result_table.predictedaccuracy", 
+                    "values": [4, 3]
+                }
+            ], 
+            "id": "pblaa_tasks_laa.pblaa_result_table", 
+            "title": "Pblaa Results By Barcode"
+        }
+    ]
+}

--- a/tests/test_models_report.py
+++ b/tests/test_models_report.py
@@ -1,9 +1,22 @@
 
 import unittest
 import json
+import logging
 
 from pbcommand.models.report import Report
+from pbcommand.pb_io import load_report_from_json
 
+_SERIALIZED_JSON_DIR = 'example-reports'
+
+from base_utils import get_data_file_from_subdir
+
+log = logging.getLogger(__name__)
+
+def _to_report(name):
+    file_name = get_data_file_from_subdir(_SERIALIZED_JSON_DIR, name)
+    log.info("loading json report from {f}".format(f=file_name))
+    r = load_report_from_json(file_name)
+    return r
 
 class TestReportModel(unittest.TestCase):
 
@@ -30,6 +43,29 @@ class TestReportModel(unittest.TestCase):
         attr = {a.id: a.value for a in r.attributes}
         self.assertEqual(attr['pbcommand_n_reads'], 300)
         self.assertEqual(attr['pbcommand_n_zmws'], 60)
+
+    def test_merge_tables(self):
+        names = ['laa_report1.json', 'laa_report2.json']
+        r = Report.merge([_to_report(names[0]), _to_report(names[1])])
+        table = r.tables[0]
+        self.assertEqual(len(table.columns), 7)
+        self.assertEqual(
+            [col.header for col in table.columns],
+            ['BarcodeName', 'FastaName', 'CoarseCluster', 'Phase',
+             'TotalCoverage', 'SequenceLength', 'PredictedAccuracy'])
+        for col in table.columns:
+            self.assertEqual(len(col.values), 4)
+            if col.header == 'BarcodeName':
+                self.assertEqual(
+                    col.values,
+                    ['Barcode1', 'Barcode2', 'Barcode4', 'Barcode3'])
+            elif col.header == 'FastaName':
+                self.assertEqual(
+                    col.values,
+                    ['BarcodeFasta1', 'BarcodeFasta2', 'BarcodeFasta4',
+                     'BarcodeFasta3'])
+            else:
+                self.assertEqual(col.values, [1, 2, 4, 3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Table merging occurs only for tables with the same table.id and same set of
  column IDs, then merges columns by column.id. 
  - Tables with unique IDs are passed through
  - Tables with non-unique IDs that don't meet the above criteria result in an assertion error.
- Column merging stacks column values after a few assertions

Test data is fake for now, will be updated if significantly different from actual report tables emitted by laa.
