### PR TITLE
tmp_dir, tmp_file support in tool contracts

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 2, 14)
+VERSION = (0, 2, 15)
 
 
 def get_version():

--- a/pbcommand/models/tool_contract.py
+++ b/pbcommand/models/tool_contract.py
@@ -123,7 +123,7 @@ class ToolContractTask(object):
 
     TASK_TYPE_ID = TaskTypes.STANDARD
 
-    def __init__(self, task_id, name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resources):
+    def __init__(self, task_id, name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resources, tmp_dir=None, tmp_file=None):
         """
         Core metadata for a commandline task
 
@@ -153,6 +153,8 @@ class ToolContractTask(object):
         self.options = tool_options
         self.nproc = nproc
         self.resources = resources
+        self.tmp_dir = tmp_dir
+        self.tmp_file = tmp_file
 
     def __repr__(self):
         _d = dict(k=self.__class__.__name__, i=self.task_id, t=self.is_distributed, n=self.name)
@@ -172,7 +174,9 @@ class ToolContractTask(object):
                   schema_options=opts,
                   nproc=self.nproc,
                   resource_types=self.resources,
-                  _comment="Created by v{v}".format(v=__version__))
+                  _comment="Created by v{v}".format(v=__version__),
+                  tmp_dir=self.tmp_dir,
+                  tmp_file=self.tmp_file)
         return _t
 
 
@@ -181,13 +185,14 @@ class ScatterToolContractTask(ToolContractTask):
     TASK_TYPE_ID = TaskTypes.SCATTERED
 
     def __init__(self, task_id, name, description, version, is_distributed,
-                 input_types, output_types, tool_options, nproc, resources, chunk_keys, max_nchunks):
+                 input_types, output_types, tool_options, nproc, resources,
+                 chunk_keys, max_nchunks, tmp_dir=None, tmp_file=None):
         """Scatter tasks have a special output signature of [FileTypes.CHUNK]
 
         The chunk keys are the expected to be written to the chunk.json file
         """
         super(ScatterToolContractTask, self).__init__(task_id, name, description, version, is_distributed,
-                                                      input_types, output_types, tool_options, nproc, resources)
+                                                      input_types, output_types, tool_options, nproc, resources, tmp_dir, tmp_file)
         self.chunk_keys = chunk_keys
         # int or $max_chunks symbol
         self.max_nchunks = max_nchunks
@@ -242,7 +247,7 @@ class ResolvedToolContractTask(object):
     TASK_TYPE_ID = TaskTypes.STANDARD
 
     def __init__(self, task_id, is_distributed, input_files, output_files,
-                 options, nproc, resources):
+                 options, nproc, resources, tmp_dir, tmp_file):
         self.task_id = task_id
         self.is_distributed = is_distributed
         self.input_files = input_files
@@ -250,6 +255,8 @@ class ResolvedToolContractTask(object):
         self.options = options
         self.nproc = nproc
         self.resources = resources
+        self.tmp_dir = tmp_dir
+        self.tmp_file = tmp_file
 
     def __repr__(self):
         _d = dict(k=self.__class__.__name__, i=self.task_id,
@@ -267,15 +274,17 @@ class ResolvedToolContractTask(object):
                   nproc=self.nproc,
                   resources=self.resources,
                   options=self.options,
-                  _comment=comment)
+                  _comment=comment,
+                  tmp_dir=self.tmp_dir,
+                  tmp_file=self.tmp_file)
         return tc
 
 
 class ResolvedScatteredToolContractTask(ResolvedToolContractTask):
     TASK_TYPE_ID = TaskTypes.SCATTERED
 
-    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, max_nchunks, chunk_keys):
-        super(ResolvedScatteredToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources)
+    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, max_nchunks, chunk_keys, tmp_dir, tmp_file):
+        super(ResolvedScatteredToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources, tmp_dir, tmp_file)
         self.max_nchunks = max_nchunks
         # these can be used to verified the output chunk.json
         # after the task has been run
@@ -291,12 +300,12 @@ class ResolvedScatteredToolContractTask(ResolvedToolContractTask):
 class ResolvedGatherToolContractTask(ResolvedToolContractTask):
     TASK_TYPE_ID = TaskTypes.GATHERED
 
-    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, chunk_key):
+    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, chunk_key, tmp_dir, tmp_file):
         """
         The chunk key is used in the pluck specific chunk values from
         PipelineChunks. This makes gather tasks (i.e., GffGather) generalized.
         """
-        super(ResolvedGatherToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources)
+        super(ResolvedGatherToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources, tmp_dir, tmp_file)
         self.chunk_key = chunk_key
 
     def to_dict(self):

--- a/pbcommand/models/tool_contract.py
+++ b/pbcommand/models/tool_contract.py
@@ -6,7 +6,7 @@ Author: Michael Kocher
 import abc
 
 import pbcommand
-from pbcommand.models import TaskTypes
+from pbcommand.models import TaskTypes, ResourceTypes
 
 __version__ = pbcommand.get_version()
 
@@ -123,7 +123,7 @@ class ToolContractTask(object):
 
     TASK_TYPE_ID = TaskTypes.STANDARD
 
-    def __init__(self, task_id, name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resources, tmp_dir=None, tmp_file=None):
+    def __init__(self, task_id, name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resources, tmp_dir=ResourceTypes.TMP_DIR, tmp_file=ResourceTypes.TMP_FILE):
         """
         Core metadata for a commandline task
 

--- a/pbcommand/pb_io/tool_contract_io.py
+++ b/pbcommand/pb_io/tool_contract_io.py
@@ -97,8 +97,10 @@ def __core_resolved_tool_contract_task_from_d(d):
     # int
     nproc = _get("nproc")
     resource_types = _get("resources")
+    tmp_dir = _get("tmp_dir")
+    tmp_file = _get("tmp_file")
 
-    return tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types
+    return tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, tmp_dir, tmp_file
 
 
 def __to_rtc_from_d(d):
@@ -112,31 +114,33 @@ def __to_rtc_from_d(d):
 def _standard_resolved_tool_contract_from_d(d):
     """Load a 'Standard' CLI task type"""
 
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, tmp_dir, tmp_file = __core_resolved_tool_contract_task_from_d(d)
 
     task = ResolvedToolContractTask(tool_contract_id, is_distributed,
                                     input_files, output_files,
-                                    tool_options, nproc, resource_types)
+                                    tool_options, nproc, resource_types,
+                                    tmp_dir, tmp_file)
     return __to_rtc_from_d(d)(task)
 
 
 def _scatter_resolved_tool_contract_from_d(d):
     """Load a Gathered Tool Contract """
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, tmp_dir, tmp_file = __core_resolved_tool_contract_task_from_d(d)
     max_nchunks = d[Constants.RTOOL][Constants.MAX_NCHUNKS]
     chunk_keys = d[Constants.RTOOL][Constants.CHUNK_KEYS]
-    task = ResolvedScatteredToolContractTask(tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, max_nchunks, chunk_keys)
+    task = ResolvedScatteredToolContractTask(tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, max_nchunks, chunk_keys, tmp_dir, tmp_file)
 
     return __to_rtc_from_d(d)(task)
 
 
 def _gather_resolved_tool_contract_from_d(d):
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, tmp_dir, tmp_file = __core_resolved_tool_contract_task_from_d(d)
 
     chunk_key = d[Constants.RTOOL][Constants.GATHER_CHUNK_KEY]
     task = ResolvedGatherToolContractTask(tool_contract_id, is_distributed,
                                       input_files, output_files,
-                                      tool_options, nproc, resource_types, chunk_key)
+                                      tool_options, nproc, resource_types,
+                                      chunk_key, tmp_dir, tmp_file)
     return __to_rtc_from_d(d)(task)
 
 
@@ -226,7 +230,9 @@ def __core_tool_contract_task_from(d):
     tool_options = _get("schema_options")
     nproc = _get("nproc")
     resource_types = _get("resource_types")
-    return task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types
+    tmp_dir = d[Constants.TOOL].get("tmp_dir", None)
+    tmp_file = d[Constants.TOOL].get("tmp_file", None)
+    return task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types, tmp_dir, tmp_file
 
 
 def __to_tc_from_d(d):
@@ -239,18 +245,19 @@ def __to_tc_from_d(d):
 
 @_json_path_or_d
 def _standard_tool_contract_from(path_or_d):
-    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types  = __core_tool_contract_task_from(path_or_d)
+    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types, tmp_dir, tmp_file= __core_tool_contract_task_from(path_or_d)
     task = ToolContractTask(task_id, display_name, description, version,
                             is_distributed,
                             input_types,
                             output_types,
-                            tool_options, nproc, resource_types)
+                            tool_options, nproc, resource_types,
+                            tmp_dir, tmp_file)
     return __to_tc_from_d(path_or_d)(task)
 
 
 @_json_path_or_d
 def _scattered_tool_contract_from(path_or_d):
-    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types = __core_tool_contract_task_from(path_or_d)
+    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types, tmp_dir, tmp_file = __core_tool_contract_task_from(path_or_d)
 
     chunk_keys = path_or_d[Constants.TOOL][Constants.CHUNK_KEYS]
     # int, or SymbolTypes.MAX_NCHUNKS
@@ -259,18 +266,21 @@ def _scattered_tool_contract_from(path_or_d):
                                    is_distributed,
                                    input_types,
                                    output_types,
-                                   tool_options, nproc, resource_types, chunk_keys, nchunks)
+                                   tool_options, nproc, resource_types,
+                                   chunk_keys, nchunks,
+                                   tmp_dir, tmp_file)
     return __to_tc_from_d(path_or_d)(task)
 
 
 @_json_path_or_d
 def _gather_tool_contract_from(path_or_d):
-    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types = __core_tool_contract_task_from(path_or_d)
+    task_id, display_name, description, version, is_distributed, input_types, output_types, tool_options, nproc, resource_types, tmp_dir, tmp_file = __core_tool_contract_task_from(path_or_d)
     task = GatherToolContractTask(task_id, display_name, description, version,
                                   is_distributed,
                                   input_types,
                                   output_types,
-                                  tool_options, nproc, resource_types)
+                                  tool_options, nproc, resource_types,
+                                  tmp_dir, tmp_file)
     return __to_tc_from_d(path_or_d)(task)
 
 

--- a/pbcommand/resolver.py
+++ b/pbcommand/resolver.py
@@ -115,7 +115,7 @@ def _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_o
     return output_files, resolved_options, nproc, resources
 
 
-def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options):
+def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, tmp_file=None):
     """
     Convert a ToolContract into a Resolved Tool Contract.
 
@@ -142,12 +142,14 @@ def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_
                                     output_files,
                                     resolved_options,
                                     nproc,
-                                    resources)
+                                    resources,
+                                    tmp_dir=root_tmp_dir,
+                                    tmp_file=tmp_file)
 
     return ResolvedToolContract(task, tool_contract.driver)
 
 
-def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, max_nchunks, chunk_keys):
+def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, max_nchunks, chunk_keys, tmp_file=None):
     output_files, resolved_options, nproc, resources = _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_options)
     resolved_max_chunks = _resolve_max_nchunks(tool_contract.task.max_nchunks, max_nchunks)
     task = ResolvedScatteredToolContractTask(tool_contract.task.task_id,
@@ -156,11 +158,12 @@ def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, r
                                              output_files,
                                              resolved_options,
                                              nproc,
-                                             resources, resolved_max_chunks, chunk_keys)
+                                             resources, resolved_max_chunks,
+                                             chunk_keys, root_tmp_dir, tmp_file)
     return ResolvedToolContract(task, tool_contract.driver)
 
 
-def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, chunk_key):
+def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, chunk_key, tmp_file=None):
     output_files, resolved_options, nproc, resources = _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_options)
     task = ResolvedGatherToolContractTask(tool_contract.task.task_id,
                                           tool_contract.task.is_distributed,
@@ -168,5 +171,6 @@ def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, ro
                                           output_files,
                                           resolved_options,
                                           nproc,
-                                          resources, chunk_key)
+                                          resources, chunk_key, root_tmp_dir,
+                                          tmp_file)
     return ResolvedToolContract(task, tool_contract.driver)

--- a/tests/data/dev_example_resolved_tool_contract.json
+++ b/tests/data/dev_example_resolved_tool_contract.json
@@ -17,6 +17,8 @@
     "resources": [],
     "is_distributed": false,
     "task_type": "pbsmrtpipe.task_types.standard",
-    "tool_contract_id": "pbcommand.tools.dev_app"
+    "tool_contract_id": "pbcommand.tools.dev_app",
+    "tmp_dir": null,
+    "tmp_file": null
   }
 }

--- a/tests/data/resolved_tool_contract_dev_app.json
+++ b/tests/data/resolved_tool_contract_dev_app.json
@@ -18,6 +18,8 @@
         ], 
         "resources": [], 
         "task_type": "pbsmrtpipe.task_types.standard", 
-        "tool_contract_id": "pbcommand.tasks.dev_txt_app"
+        "tool_contract_id": "pbcommand.tasks.dev_txt_app",
+        "tmp_dir": null,
+        "tmp_file": null
     }
 }

--- a/tests/test_load_resolved_tool_contract.py
+++ b/tests/test_load_resolved_tool_contract.py
@@ -1,5 +1,6 @@
 import pprint
 import unittest
+import tempfile
 import logging
 import os.path
 
@@ -43,8 +44,11 @@ class TestResolveContract(unittest.TestCase):
         root_output_dir = "/tmp"
         root_tmp_dir = root_output_dir
         max_nproc = 2
-        rtc = resolve_tool_contract(tc, input_files, root_output_dir, root_tmp_dir, max_nproc, {})
+        tmp_file = tempfile.NamedTemporaryFile().name
+        rtc = resolve_tool_contract(tc, input_files, root_output_dir, root_tmp_dir, max_nproc, {}, tmp_file=tmp_file)
         log.info(pprint.pformat(rtc))
         self.assertIsNotNone(rtc)
         self.assertEqual(os.path.basename(rtc.task.output_files[0]),
             "output.txt")
+        self.assertEqual(rtc.task.tmp_dir, "/tmp")
+        self.assertEqual(rtc.task.tmp_file, tmp_file)


### PR DESCRIPTION
I think I wrote this in such a way that pbsmrtpipe won't break and the existing tool contracts won't have to be updated.  It seems to be running fine for me, anyway.
