### PR TITLE
Add title to Report model. Update to 0.3.9

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 8)
+VERSION = (0, 3, 9)
 
 
 def get_version():

--- a/pbcommand/models/report.py
+++ b/pbcommand/models/report.py
@@ -560,9 +560,10 @@ class Report(BaseReportElement):
     It can be serialized to json.
     """
 
-    def __init__(self, id_, tables=(), attributes=(), plotgroups=(), dataset_uuids=()):
+    def __init__(self, id_, title=None, tables=(), attributes=(), plotgroups=(), dataset_uuids=()):
         """
         :param id_: (str) Should be a string that identifies the report, like 'adapter'.
+        :param title: Display name of report Defaults to the Report+id if None (added in 0.3.9)
         :param tables: (list of table instances)
         :param attributes: (list of attribute instances)
         :param plotgroups: (list of plot group instances)
@@ -572,6 +573,8 @@ class Report(BaseReportElement):
         self._attributes = []
         self._plotgroups = []
         self._tables = []
+        self.title = "Report {i}".format(i=self.id) if title is None else title
+
         if tables:
             for table in tables:
                 self.add_table(table)
@@ -615,10 +618,11 @@ class Report(BaseReportElement):
     def __repr__(self):
         _d = dict(k=self.__class__.__name__,
                   i=self.id,
+                  n=self.title,
                   a=len(self.attributes),
                   p=len(self.plotGroups),
                   t=len(self.tables))
-        return "<{k} id:{i} nattributes:{a} nplot_groups:{p} ntables:{t} >".format(**_d)
+        return "<{k} id:{i} title:{n} nattributes:{a} nplot_groups:{p} ntables:{t} >".format(**_d)
 
     @property
     def attributes(self):
@@ -659,6 +663,7 @@ class Report(BaseReportElement):
         version = pbcommand.get_version()
 
         d = BaseReportElement.to_dict(self, id_parts=id_parts)
+        d['title'] = self.title
         d['_version'] = version
         d['_changelist'] = "UNKNOWN"
         d['dataset_uuids'] = list(set(self._dataset_uuids))

--- a/pbcommand/pb_io/report.py
+++ b/pbcommand/pb_io/report.py
@@ -89,6 +89,12 @@ def dict_to_report(dct):
 
     report_id = dct['id']
 
+    # Legacy Reports > 0.3.9 will not have the title key
+    if 'title' in dct:
+        title = dct['title']
+    else:
+        title = "Report {i}".format(i=report_id)
+
     plot_groups = []
     if 'plotGroups' in dct:
         pg = dct['plotGroups']
@@ -105,7 +111,10 @@ def dict_to_report(dct):
         t = _to_table(table_d)
         tables.append(t)
 
-    report = Report(report_id, plotgroups=plot_groups, tables=tables,
+    report = Report(report_id,
+                    title=title,
+                    plotgroups=plot_groups,
+                    tables=tables,
                     attributes=attributes)
 
     return report

--- a/tests/data/example-reports/overview.json
+++ b/tests/data/example-reports/overview.json
@@ -1,6 +1,7 @@
 {
   "tables": [],
-  "_version": "2.1",
+  "_comment": "Manually updated by MK for 0.3.9",
+  "_version": "0.3.9",
   "_changelist": 127707,
   "attributes": [
     {
@@ -15,5 +16,6 @@
     }
   ],
   "id": "overview",
+  "title": "Overview Report",
   "plotGroups": []
 }

--- a/tests/test_pb_io_report.py
+++ b/tests/test_pb_io_report.py
@@ -30,6 +30,9 @@ class TestSerializationOverviewReport(unittest.TestCase):
     def test_id(self):
         self.assertEqual(self.report.id, "overview")
 
+    def test_title(self):
+        self.assertEqual(self.report.title, "Overview Report")
+
     def test_attributes(self):
         self.assertTrue(len(self.report.attributes), 2)
 


### PR DESCRIPTION
- If title=None, the title will be generated from the report id
- All the title properties of the models should be migrated to be a required value
