### PR TITLE
More fixes for cli model. Update to 0.3.10

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 9)
+VERSION = (0, 3, 10)
 
 
 def get_version():

--- a/pbcommand/cli/core.py
+++ b/pbcommand/cli/core.py
@@ -32,10 +32,13 @@ from pbcommand.pb_io.tool_contract_io import load_resolved_tool_contract_from
 
 def get_default_argparser(version, description):
     """
-    Everyone MUST use this to create an instance on a argparser python parser.
+    Everyone should use this to create an instance on a argparser python parser.
 
-    :param version:
-    :param description:
+
+    *This should be replaced updated to have the required base options*
+
+    :param version: Version of your tool
+    :param description: Description of your tool
     :return:
     :rtype: ArgumentParser
     """
@@ -45,9 +48,29 @@ def get_default_argparser(version, description):
     return p
 
 
-def get_default_argparser_with_base_opts(version, description):
-    """Return a parser with the default log related options"""
-    return add_base_options(get_default_argparser(version, description))
+def get_default_argparser_with_base_opts(version, description, default_level="INFO"):
+    """Return a parser with the default log related options
+
+    If you don't want the default log behavior to go to stdout, then set
+    the default log level to be "ERROR". This will essentially suppress all
+    output to stdout.
+
+    Default behavior will only emit to stderr. This is essentially a '--quiet'
+    default mode.
+
+    my-tool --my-opt=1234 file_in.txt
+
+    To override the default behavior and add a chatty-er stdout
+
+    my-tool --my-opt=1234 --log-level=INFO file_in.txt
+
+    Or write the console output to write the log file to an explict file and
+    leave the stdout untouched.
+
+    my-tool --my-opt=1234 --log-level=DEBUG --log-file=file.log file_in.txt
+
+    """
+    return add_base_options(get_default_argparser(version, description), default_level=default_level)
 
 
 def _pacbio_main_runner(alog, setup_log_func, exe_main_func, *args, **kwargs):

--- a/pbcommand/common_options.py
+++ b/pbcommand/common_options.py
@@ -14,6 +14,18 @@ def add_debug_option(p):
     return p
 
 
+def add_log_debug_option(p):
+    """This requires the log-level option"""
+    p.add_argument('--debug', action="store_true", default=False, help="Alias for setting log level to DEBUG")
+    return p
+
+
+def add_log_quiet_option(p):
+    """This requires the log-level option"""
+    p.add_argument('--quiet', action="store_true", default=False, help="Alias for setting log level to CRITICAL to suppress output.")
+    return p
+
+
 def add_log_level_option(p, default_level='INFO'):
     """Add logging level with a default value"""
     p.add_argument('--log-level', choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
@@ -40,9 +52,29 @@ def add_emit_tool_contract_option(p):
     return p
 
 
-def add_base_options(p):
+def add_base_options(p, default_level='INFO'):
+    """Add the core logging options to the parser and set the default log level
+
+    If you don't want the default log behavior to go to stdout, then set
+    the default log level to be "ERROR". This will essentially suppress all
+    output to stdout.
+
+    Default behavior will only emit to stderr. This is essentially a '--quiet'
+    default mode.
+
+    my-tool --my-opt=1234 file_in.txt
+
+    To override the default behavior:
+
+    my-tool --my-opt=1234 --log-level=INFO file_in.txt
+
+    Or write the file to an explict log file
+
+    my-tool --my-opt=1234 --log-level=DEBUG --log-file=file.log file_in.txt
+
+    """
     # This should automatically/required be added to be added from get_default_argparser
-    return add_debug_option(add_log_level_option(add_log_file_option(p)))
+    return add_log_quiet_option(add_log_debug_option(add_log_level_option(add_log_file_option(p), default_level=default_level)))
 
 
 def add_base_options_with_emit_tool_contract(p):

--- a/pbcommand/services/models.py
+++ b/pbcommand/services/models.py
@@ -1,7 +1,11 @@
 """Services Specific Data Models"""
 from collections import namedtuple
 import uuid
+
 import iso8601
+
+from requests.exceptions import RequestException
+
 
 
 def to_ascii(s):
@@ -56,6 +60,11 @@ class ServiceJob(namedtuple("ServiceJob", 'id uuid name state path job_type crea
 
 class JobExeError(ValueError):
     """Service Job failed to complete successfully"""
+    pass
+
+
+class SmrtServerConnectionError(RequestException):
+    """This is blunt to catch all status related errors"""
     pass
 
 

--- a/pbcommand/utils.py
+++ b/pbcommand/utils.py
@@ -20,6 +20,7 @@ log.addHandler(logging.NullHandler())  # suppress the annoying no handlers msg
 
 
 class Constants(object):
+    LOG_FMT_ONLY_MSG = '%(message)s'
     LOG_FMT_ERR = '%(message)s'
     LOG_FMT_LVL = '[%(levelname)s] %(message)s '
     LOG_FMT_MIN = '[%(asctime)-15sZ] %(message)s'

--- a/pbcommand/validators.py
+++ b/pbcommand/validators.py
@@ -26,6 +26,26 @@ validate_dir = functools.partial(_validate_resource, os.path.isdir)
 validate_output_dir = functools.partial(_validate_resource, os.path.isdir)
 
 
+def validate_or(f1, f2, error_msg):
+    """
+    Apply Valid functions f1, then f2 (if failure occurs)
+
+    :param error_msg: Default message to print
+    """
+    @functools.wraps
+    def wrapper(path):
+        try:
+            return f1(path)
+        except Exception:
+            try:
+                return f2(path)
+            except Exception as e:
+                log.error("{m} {p} \n. {e}".format(m=error_msg, p=path, e=repr(e)))
+                raise
+
+    return wrapper
+
+
 def validate_report(report_file_name):
     """
     Raise ValueError if report contains path seps


### PR DESCRIPTION
- Add parser with base options (this should eventually replace get_default_argparser)
- `--debug` has a slightly new meaning and is short `--log-level=DEBUG`
- `--quiet` is short for `--log-level=ERROR`
- `--log-file` enables will write the file to or stdout if the file isn't provided
- `--log-level` defaults to INFO
- logging error handler setup on stderr. Tools should be encouraged to log the error and never write to sys.stderr directly
- No more base options will be added.
- Fixes clean up to Sal
