### PR TITLE
sleep before retrieving job status for the first time

### DIFF
--- a/pbcommand/services/service_access_layer.py
+++ b/pbcommand/services/service_access_layer.py
@@ -185,6 +185,7 @@ def _block_for_job_to_complete(sal, job_id, time_out=600, sleep_time=2):
     if the job fails during the polling process or times out
     """
 
+    time.sleep(sleep_time)
     job = _get_job_by_id_or_raise(sal, job_id, KeyError)
 
     log.debug("time_out = {t}".format(t=time_out))


### PR DESCRIPTION
Trying to fix the weird errors I get in services tests - erring on the side of minimal code changes, at the expense of efficiency
