### PR TITLE
Registry runner fixes:

### DIFF
--- a/pbcommand/cli/examples/dev_quick_hello_world.py
+++ b/pbcommand/cli/examples/dev_quick_hello_world.py
@@ -22,6 +22,7 @@ def _example_main(input_files, output_files, **kwargs):
 
 @registry("dev_qhello_world", "0.2.1", FileTypes.FASTA, FileTypes.FASTA, nproc=1, options=dict(alpha=1234))
 def run_rtc(rtc):
+    log.debug("Dev Quick Hello World Example. Fasta -> Fasta with option alpha=1234")
     return _example_main(rtc.task.input_files[0], rtc.task.output_files[0], nproc=rtc.task.nproc)
 
 
@@ -57,4 +58,7 @@ def run_rtc(rtc):
 
 
 if __name__ == '__main__':
-    sys.exit(registry_runner(registry, sys.argv[1:]))
+    default_log_level = logging.DEBUG
+    sys.exit(registry_runner(registry,
+                             sys.argv[1:],
+                             default_log_level=default_log_level))


### PR DESCRIPTION
- configure registery runner with default log-level
- supports new common base options (--quiet/--debug) to configure log
- logger setup using newer setup_logger model
- when the RTC id is not found, show the ids in the registry
- add run time to the output
- if the exit code is non-zero log the message and an error
