### PR TITLE
Standardize log options

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 16)
+VERSION = (0, 3, 17)
 
 
 def get_version():

--- a/pbcommand/cli/core.py
+++ b/pbcommand/cli/core.py
@@ -108,7 +108,16 @@ def _pacbio_main_runner(alog, setup_log_func, exe_main_func, *args, **kwargs):
 
     # If level is provided at the parser level, this will override all other
     # settings. This is defined in pbcommand.common_options.add_log_level_option
-    if hasattr(pargs, 'log_level'):
+    if hasattr(pargs, 'verbosity') and pargs.verbosity > 0:
+        if pargs.verbosity >= 2:
+            level = logging.DEBUG
+        else:
+            level = logging.INFO
+    elif hasattr(pargs, 'debug') and pargs.debug:
+        level = logging.DEBUG
+    elif hasattr(pargs, 'quiet') and pargs.quiet:
+        level = logging.ERROR
+    elif hasattr(pargs, 'log_level'):
         level = logging.getLevelName(pargs.log_level)
 
     # None will default to stdout

--- a/pbcommand/cli/utils.py
+++ b/pbcommand/cli/utils.py
@@ -107,11 +107,16 @@ def main_runner(argv, parser, exe_runner_func, setup_log_func, alog):
     # log.debug(args)
 
     # setup log
-    if hasattr(args, 'debug'):
-        if args.debug:
+    _have_log_setup = False
+    if hasattr(args, 'quiet') and args.quiet:
+        setup_log_func(alog, level=logging.ERROR)
+    elif hasattr(args, 'verbosity') and args.verbosity > 0:
+        if args.verbosity >= 2:
             setup_log_func(alog, level=logging.DEBUG)
         else:
-            alog.addHandler(logging.NullHandler())
+            setup_log_func(alog, level=logging.INFO)
+    elif hasattr(args, 'debug') and args.debug:
+        setup_log_func(alog, level=logging.DEBUG)
     else:
         alog.addHandler(logging.NullHandler())
 

--- a/pbcommand/common_options.py
+++ b/pbcommand/common_options.py
@@ -8,9 +8,8 @@ EMIT_TOOL_CONTRACT_OPTION = "--emit-tool-contract"
 
 
 def add_debug_option(p):
-    # FIXME. This should be re-purposed to launch a debugger with --ipdb or --pdb
-    # logging should be handled via --log-* options
-    p.add_argument('--debug', action="store_true", default=False, help="Debug to stdout")
+    p.add_argument("--pdb", action="store_true", default=False,
+                   help="Enable Python debugger")
     return p
 
 
@@ -23,6 +22,16 @@ def add_log_debug_option(p):
 def add_log_quiet_option(p):
     """This requires the log-level option"""
     p.add_argument('--quiet', action="store_true", default=False, help="Alias for setting log level to CRITICAL to suppress output.")
+    return p
+
+
+def add_log_verbose_option(p):
+    p.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbosity",
+        action="count",
+        help="Set the verbosity level.")
     return p
 
 
@@ -74,8 +83,9 @@ def add_base_options(p, default_level='INFO'):
 
     """
     # This should automatically/required be added to be added from get_default_argparser
-    return add_debug_option(add_log_level_option(add_log_file_option(p),
-                                                 default_level=default_level))
+    return add_log_verbose_option(add_log_quiet_option(add_log_debug_option(
+        add_log_level_option(add_log_file_option(p),
+                             default_level=default_level))))
 
 
 def add_common_options(p, default_level='INFO'):

--- a/pbcommand/models/parser.py
+++ b/pbcommand/models/parser.py
@@ -279,10 +279,15 @@ class PyParser(PbParserBase):
 
     def __init__(self, tool_id, version, name, description, subcomponents=()):
         super(PyParser, self).__init__(tool_id, version, name, description)
-        self.parser = argparse.ArgumentParser(version=version,
+        self.parser = argparse.ArgumentParser(#version=version,
                                               description=description,
                                               formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                               add_help=True)
+        self.parser.version = version
+        self.parser.add_argument('--version',
+                                 action="version",
+                                 help="show program's version number and exit")
+
         if subcomponents:
             add_subcomponent_versions_option(self.parser, subcomponents)
 

--- a/tests/test_common_cmdline_core.py
+++ b/tests/test_common_cmdline_core.py
@@ -17,7 +17,7 @@ def args_runner(*args, **kwargs):
 
 def _example_parser():
     p = get_default_argparser("1.0.0", "Example Mock Parser")
-    p = CU.add_debug_option(p)
+    p = CU.add_log_debug_option(p)
     p.add_argument('example_file', type=str, help="No testing of existence")
     return p
 


### PR DESCRIPTION
In my hands (using bamSieve in pbcoretools as an example), these changes appear to give us exactly the kind of control we want when used in combination with pbcommand.utils.setup_log.  I'll have to update most of the downstream tools to remove redundant options, of course.
