### PR TITLE
add log_level to resolved tool contract model

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 17)
+VERSION = (0, 3, 18)
 
 
 def get_version():

--- a/pbcommand/models/tool_contract.py
+++ b/pbcommand/models/tool_contract.py
@@ -272,7 +272,7 @@ class ResolvedToolContractTask(object):
     TASK_TYPE_ID = TaskTypes.STANDARD
 
     def __init__(self, task_id, is_distributed, input_files, output_files,
-                 options, nproc, resources):
+                 options, nproc, resources, log_level="INFO"):
         self.task_id = task_id
         self.is_distributed = is_distributed
         self.input_files = input_files
@@ -280,6 +280,7 @@ class ResolvedToolContractTask(object):
         self.options = options
         self.nproc = nproc
         self.resources = resources
+        self.log_level = log_level
 
     @property
     def tmpdir_resources(self):
@@ -305,15 +306,16 @@ class ResolvedToolContractTask(object):
                   nproc=self.nproc,
                   resources=[r.to_dict() for r in self.resources],
                   options=self.options,
-                  _comment=comment)
+                  _comment=comment,
+                  log_level=self.log_level)
         return tc
 
 
 class ResolvedScatteredToolContractTask(ResolvedToolContractTask):
     TASK_TYPE_ID = TaskTypes.SCATTERED
 
-    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, max_nchunks, chunk_keys):
-        super(ResolvedScatteredToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources)
+    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, max_nchunks, chunk_keys, log_level="INFO"):
+        super(ResolvedScatteredToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources, log_level)
         self.max_nchunks = max_nchunks
         # these can be used to verified the output chunk.json
         # after the task has been run
@@ -329,12 +331,12 @@ class ResolvedScatteredToolContractTask(ResolvedToolContractTask):
 class ResolvedGatherToolContractTask(ResolvedToolContractTask):
     TASK_TYPE_ID = TaskTypes.GATHERED
 
-    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, chunk_key):
+    def __init__(self, task_id, is_distributed, input_files, output_files, options, nproc, resources, chunk_key, log_level="INFO"):
         """
         The chunk key is used in the pluck specific chunk values from
         PipelineChunks. This makes gather tasks (i.e., GffGather) generalized.
         """
-        super(ResolvedGatherToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources)
+        super(ResolvedGatherToolContractTask, self).__init__(task_id, is_distributed, input_files, output_files, options, nproc, resources, log_level)
         self.chunk_key = chunk_key
 
     def to_dict(self):

--- a/pbcommand/pb_io/tool_contract_io.py
+++ b/pbcommand/pb_io/tool_contract_io.py
@@ -97,10 +97,11 @@ def __core_resolved_tool_contract_task_from_d(d):
     tool_options = _get("options")
     # int
     nproc = _get("nproc")
+    log_level = _get("log_level")
 
     resource_types = [ToolContractResolvedResource.from_d(dx) for dx in _get("resources")]
 
-    return tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types
+    return tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, log_level
 
 
 def __to_rtc_from_d(d):
@@ -114,31 +115,33 @@ def __to_rtc_from_d(d):
 def _standard_resolved_tool_contract_from_d(d):
     """Load a 'Standard' CLI task type"""
 
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, log_level = __core_resolved_tool_contract_task_from_d(d)
 
     task = ResolvedToolContractTask(tool_contract_id, is_distributed,
                                     input_files, output_files,
-                                    tool_options, nproc, resource_types)
+                                    tool_options, nproc, resource_types,
+                                    log_level)
     return __to_rtc_from_d(d)(task)
 
 
 def _scatter_resolved_tool_contract_from_d(d):
     """Load a Gathered Tool Contract """
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, log_level = __core_resolved_tool_contract_task_from_d(d)
     max_nchunks = d[Constants.RTOOL][Constants.MAX_NCHUNKS]
     chunk_keys = d[Constants.RTOOL][Constants.CHUNK_KEYS]
-    task = ResolvedScatteredToolContractTask(tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, max_nchunks, chunk_keys)
+    task = ResolvedScatteredToolContractTask(tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, max_nchunks, chunk_keys, log_level=log_level)
 
     return __to_rtc_from_d(d)(task)
 
 
 def _gather_resolved_tool_contract_from_d(d):
-    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types = __core_resolved_tool_contract_task_from_d(d)
+    tool_contract_id, is_distributed, input_files, output_files, tool_options, nproc, resource_types, log_level = __core_resolved_tool_contract_task_from_d(d)
 
     chunk_key = d[Constants.RTOOL][Constants.GATHER_CHUNK_KEY]
     task = ResolvedGatherToolContractTask(tool_contract_id, is_distributed,
                                           input_files, output_files,
-                                          tool_options, nproc, resource_types, chunk_key)
+                                          tool_options, nproc, resource_types,
+                                          chunk_key, log_level=log_level)
     return __to_rtc_from_d(d)(task)
 
 

--- a/pbcommand/resolver.py
+++ b/pbcommand/resolver.py
@@ -153,7 +153,7 @@ def _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_o
     return output_files, resolved_options, nproc, resolved_resources
 
 
-def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, is_distributable):
+def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, is_distributable, log_level="INFO"):
     """
     Convert a ToolContract into a Resolved Tool Contract.
 
@@ -183,12 +183,13 @@ def resolve_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_
                                     output_files,
                                     resolved_options,
                                     nproc,
-                                    resources)
+                                    resources,
+                                    log_level=log_level)
 
     return ResolvedToolContract(task, tool_contract.driver)
 
 
-def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, max_nchunks, chunk_keys, is_distributable):
+def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, max_nchunks, chunk_keys, is_distributable, log_level="INFO"):
     output_files, resolved_options, nproc, resources = _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_options, tmp_dir=root_tmp_dir)
     resolved_max_chunks = _resolve_max_nchunks(tool_contract.task.max_nchunks, max_nchunks)
     task = ResolvedScatteredToolContractTask(tool_contract.task.task_id,
@@ -197,11 +198,11 @@ def resolve_scatter_tool_contract(tool_contract, input_files, root_output_dir, r
                                              output_files,
                                              resolved_options,
                                              nproc,
-                                             resources, resolved_max_chunks, chunk_keys)
+                                             resources, resolved_max_chunks, chunk_keys, log_level=log_level)
     return ResolvedToolContract(task, tool_contract.driver)
 
 
-def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, chunk_key, is_distributable):
+def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, root_tmp_dir, max_nproc, tool_options, chunk_key, is_distributable, log_level="INFO"):
     output_files, resolved_options, nproc, resources = _resolve_core(tool_contract, input_files, root_output_dir, max_nproc, tool_options, tmp_dir=root_tmp_dir)
     task = ResolvedGatherToolContractTask(tool_contract.task.task_id,
                                           tool_contract.task.is_distributed and is_distributable,
@@ -209,5 +210,6 @@ def resolve_gather_tool_contract(tool_contract, input_files, root_output_dir, ro
                                           output_files,
                                           resolved_options,
                                           nproc,
-                                          resources, chunk_key)
+                                          resources, chunk_key,
+                                          log_level=log_level)
     return ResolvedToolContract(task, tool_contract.driver)

--- a/tests/data/dev_example_resolved_tool_contract.json
+++ b/tests/data/dev_example_resolved_tool_contract.json
@@ -17,6 +17,7 @@
     "resources": [],
     "is_distributed": false,
     "task_type": "pbsmrtpipe.task_types.standard",
-    "tool_contract_id": "pbcommand.tools.dev_app"
+    "tool_contract_id": "pbcommand.tools.dev_app",
+    "log_level": "INFO"
   }
 }

--- a/tests/data/resolved_contract_01.json
+++ b/tests/data/resolved_contract_01.json
@@ -18,6 +18,7 @@
         ], 
         "resources": [], 
         "task_type": "pbsmrtpipe.task_types.standard", 
-        "tool_contract_id": "pbcommand.tasks.dev_txt_app"
+        "tool_contract_id": "pbcommand.tasks.dev_txt_app",
+        "log_level": "INFO"
     }
 }

--- a/tests/data/resolved_tool_contract_dev_app.json
+++ b/tests/data/resolved_tool_contract_dev_app.json
@@ -18,6 +18,7 @@
         ], 
         "resources": [], 
         "task_type": "pbsmrtpipe.task_types.standard", 
-        "tool_contract_id": "pbcommand.tasks.dev_txt_app"
+        "tool_contract_id": "pbcommand.tasks.dev_txt_app",
+        "log_level": "INFO"
     }
 }


### PR DESCRIPTION
@mpkocher please review - in combination with pbsmrtpipe changes, this will propagate the log level to the underlying task and respect it when logging is set up.  Note that since pbsmrtpipe seems to be hard-coded with a log level of DEBUG, this may produce an awful lot of output; do we want to control that separately?
