### PR TITLE
standardize logging in pbcommand.cli.quick

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 18)
+VERSION = (0, 3, 19)
 
 
 def get_version():

--- a/pbcommand/cli/core.py
+++ b/pbcommand/cli/core.py
@@ -30,7 +30,7 @@ from pbcommand.common_options import (RESOLVED_TOOL_CONTRACT_OPTION,
                                       EMIT_TOOL_CONTRACT_OPTION,
                                       add_resolved_tool_contract_option,
                                       add_base_options)
-
+from pbcommand.utils import get_parsed_args_log_level
 from pbcommand.pb_io.tool_contract_io import load_resolved_tool_contract_from
 
 
@@ -85,22 +85,6 @@ def get_default_argparser_with_base_opts(version, description, default_level="IN
     return add_base_options(get_default_argparser(version, description), default_level=default_level)
 
 
-def __get_parsed_args_log_level(pargs, default_level=logging.INFO):
-    level = default_level
-    if hasattr(pargs, 'verbosity') and pargs.verbosity > 0:
-        if pargs.verbosity >= 2:
-            level = logging.DEBUG
-        else:
-            level = logging.INFO
-    elif hasattr(pargs, 'debug') and pargs.debug:
-        level = logging.DEBUG
-    elif hasattr(pargs, 'quiet') and pargs.quiet:
-        level = logging.ERROR
-    elif hasattr(pargs, 'log_level'):
-        level = logging.getLevelName(pargs.log_level)
-    return level
-
-
 def _pacbio_main_runner(alog, setup_log_func, exe_main_func, *args, **kwargs):
     """
     Runs a general func and logs results. The return type is expected to be an (int) return code.
@@ -126,7 +110,7 @@ def _pacbio_main_runner(alog, setup_log_func, exe_main_func, *args, **kwargs):
     if 'level' in kwargs:
         level = kwargs.pop('level')
     else:
-        level = __get_parsed_args_log_level(pargs)
+        level = get_parsed_args_log_level(pargs)
 
     # None will default to stdout
     log_file = getattr(pargs, 'log_file', None)
@@ -235,7 +219,7 @@ def pacbio_args_or_contract_runner(argv,
         # otherwise use the log level in the resolved tool contract.  note that
         # this takes advantage of the fact that argparse allows us to use
         # NOTSET as the default level even though it's not one of the choices.
-        log_level = __get_parsed_args_log_level(args_tmp,
+        log_level = get_parsed_args_log_level(args_tmp,
             default_level=logging.NOTSET)
         if log_level == logging.NOTSET:
             log_level = resolved_tool_contract.task.log_level

--- a/pbcommand/cli/quick.py
+++ b/pbcommand/cli/quick.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 import time
 
 import pbcommand
-from .core import get_default_argparser
+from .core import get_default_argparser_with_base_opts
 from pbcommand.common_options import add_base_options, add_common_options
 
 from pbcommand.models import (ToolContractTask, ToolContract,
@@ -17,7 +17,7 @@ from pbcommand.models.parser import (to_option_schema, JsonSchemaTypes)
 from pbcommand.models.tool_contract import ToolDriver
 from pbcommand.pb_io import (load_resolved_tool_contract_from,
                              write_tool_contract)
-from pbcommand.utils import setup_log, setup_logger
+from pbcommand.utils import setup_log, setup_logger, get_parsed_args_log_level
 
 log = logging.getLogger(__name__)
 
@@ -221,17 +221,7 @@ def __args_rtc_runner(registry, default_log_level):
         def exit_msg(rcode_):
             return "Completed running {r} exitcode {e} in {t:.2f} sec.".format(r=rtc, e=rcode_, t=run_time())
 
-        level = getattr(args, 'log_level', default_log_level)
-        is_debug = getattr(args, 'debug', False)
-        is_quiet = getattr(args, 'quiet', False)
-
-        if is_debug:
-            level = logging.DEBUG
-
-        # quiet trumps debug or the provided log level
-        if is_quiet:
-            level = logging.ERROR
-
+        level = get_parsed_args_log_level(args)
         setup_logger(None, level=level)
 
         log.info("Loading pbcommand {v}".format(v=pbcommand.get_version()))
@@ -292,7 +282,7 @@ def __args_emit_all_tcs_runner(registry):
 
 def _to_registry_parser(version, description, default_log_level):
     def _f(registry):
-        p = get_default_argparser(version, description)
+        p = get_default_argparser_with_base_opts(version, description)
         sp = p.add_subparsers(help='Commands')
 
         args_summary_runner = __args_summary_runner(registry)

--- a/pbcommand/common_options.py
+++ b/pbcommand/common_options.py
@@ -1,4 +1,6 @@
 """Common options and utils that can me used in commandline utils"""
+
+import logging
 import argparse
 import sys
 
@@ -37,6 +39,8 @@ def add_log_verbose_option(p):
 
 def add_log_level_option(p, default_level='INFO'):
     """Add logging level with a default value"""
+    if isinstance(default_level, int):
+        default_level = logging.getLevelName(default_level)
     p.add_argument('--log-level', choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
                    default=default_level, help="Set log level")
     return p

--- a/pbcommand/utils.py
+++ b/pbcommand/utils.py
@@ -193,6 +193,32 @@ def setup_log(alog,
     return alog
 
 
+def get_parsed_args_log_level(pargs, default_level=logging.INFO):
+    """
+    Utility for handling logging setup flexibly in a variety of use cases,
+    assuming standard command-line arguments.
+
+    :param pargs: argparse namespace or equivalent
+    :param default_level: logging level to use if the parsed arguments do not
+                          specify one
+    """
+    level = default_level
+    if isinstance(level, basestring):
+        level = logging.getLevelName(level)
+    if hasattr(pargs, 'verbosity') and pargs.verbosity > 0:
+        if pargs.verbosity >= 2:
+            level = logging.DEBUG
+        else:
+            level = logging.INFO
+    elif hasattr(pargs, 'debug') and pargs.debug:
+        level = logging.DEBUG
+    elif hasattr(pargs, 'quiet') and pargs.quiet:
+        level = logging.ERROR
+    elif hasattr(pargs, 'log_level'):
+        level = logging.getLevelName(pargs.log_level)
+    return level
+
+
 def log_traceback(alog, ex, ex_traceback):
     """
     Log a python traceback in the log file


### PR DESCRIPTION
generalize handling of parsed logging arguments, and use common logging arguments in cli.quick
