### PR TITLE
remove extensions from output file default_name

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 19)
+VERSION = (0, 3, 20)
 
 
 def get_version():

--- a/pbcommand/cli/examples/dev_app.py
+++ b/pbcommand/cli/examples/dev_app.py
@@ -31,7 +31,7 @@ def add_args_and_options(p):
     # FileType, label, name, description
     p.add_input_file_type(FileTypes.FASTA, "fasta_in", "Fasta File", "PacBio Spec'ed fasta file")
     # File Type, label, name, description, default file name
-    p.add_output_file_type(FileTypes.FASTA, "fasta_out", "Filtered Fasta file", "Filtered Fasta file", "filter.fasta")
+    p.add_output_file_type(FileTypes.FASTA, "fasta_out", "Filtered Fasta file", "Filtered Fasta file", "filter")
     # Option id, label, default value, name, description
     # for the argparse, the read-length will be translated to --read-length and (accessible via args.read_length)
     p.add_int("pbcommand.task_options.dev_read_length", "read-length", 25, "Length filter", "Min Sequence Length filter")

--- a/pbcommand/cli/examples/dev_gather_fasta_app.py
+++ b/pbcommand/cli/examples/dev_gather_fasta_app.py
@@ -89,7 +89,7 @@ def get_parser():
     p = get_gather_pbparser(TOOL_ID, __version__, "Fasta Chunk Gather",
                             desc, driver, is_distributed=False)
     p.add_input_file_type(FileTypes.CHUNK, "chunk_json", "Chunk JSON", "Chunked Fasta JSON Out")
-    p.add_output_file_type(FileTypes.FASTA, "output", "Chunk JSON", "Output Fasta", "gathered.fasta")
+    p.add_output_file_type(FileTypes.FASTA, "output", "Chunk JSON", "Output Fasta", "gathered")
     return p
 
 

--- a/pbcommand/cli/examples/dev_mixed_app.py
+++ b/pbcommand/cli/examples/dev_mixed_app.py
@@ -51,7 +51,7 @@ def add_rtc_options(p):
     :return:
     """
     p.add_input_file_type(FileTypes.CSV, "csv", "Input CSV", "Input csv description")
-    p.add_output_file_type(FileTypes.REPORT, "rpt", "Output Report", "Output PacBio Report JSON", "example.report.json")
+    p.add_output_file_type(FileTypes.REPORT, "rpt", "Output Report", "Output PacBio Report JSON", "example.report")
     p.add_int("pbcommand.task_options.alpha", "alpha", 25, "Alpha", "Alpha description")
     return p
 

--- a/pbcommand/cli/examples/dev_quick_hello_world.py
+++ b/pbcommand/cli/examples/dev_quick_hello_world.py
@@ -38,7 +38,7 @@ def run_rtc(rtc):
 
 
 def _to_output(i, file_type):
-    default_name = "_".join([file_type.file_type_id, file_type.base_name + "_" + str(i) + "." + file_type.ext])
+    default_name = "_".join([file_type.file_type_id, file_type.base_name + "_" + str(i)])
     label = "label_" + file_type.file_type_id
     desc = "File {f}".format(f=file_type)
     return OutputFileType(file_type.file_type_id, label, repr(file_type), desc, default_name)

--- a/pbcommand/cli/examples/dev_scatter_fasta_app.py
+++ b/pbcommand/cli/examples/dev_scatter_fasta_app.py
@@ -132,7 +132,7 @@ def get_parser():
     p = get_scatter_pbparser(TOOL_ID, __version__, "Fasta Scatter",
                              desc, driver, chunk_keys, is_distributed=False)
     p.add_input_file_type(FileTypes.FASTA, "fasta_in", "Fasta In", "Fasta file to scatter")
-    p.add_output_file_type(FileTypes.CHUNK, "cjson", "Chunk JSON", "Scattered/Chunked Fasta Chunk.json", "fasta.chunks.json")
+    p.add_output_file_type(FileTypes.CHUNK, "cjson", "Chunk JSON", "Scattered/Chunked Fasta Chunk.json", "fasta.chunks")
     p.add_int("pbcommand.task_options.dev_scatter_fa_nchunks", "nchunks", 10, "Number of chunks",
               "Suggested number of chunks. May be overridden by $max_nchunks")
     return p

--- a/pbcommand/cli/examples/dev_txt_app.py
+++ b/pbcommand/cli/examples/dev_txt_app.py
@@ -37,7 +37,7 @@ def get_parser():
     # Add Input Files types
     p.add_input_file_type(FileTypes.TXT, "txt_in", "Txt file", "Generic Text File")
     # Add output files types
-    p.add_output_file_type(FileTypes.TXT, "txt_out", "Txt outfile", "Generic Output Txt file", "output.txt")
+    p.add_output_file_type(FileTypes.TXT, "txt_out", "Txt outfile", "Generic Output Txt file", "output")
     p.add_int("pbcommand.task_options.dev_max_nlines", "max_nlines", 10, "Max Lines", "Max Number of lines to Copy")
     return p
 

--- a/pbcommand/models/common.py
+++ b/pbcommand/models/common.py
@@ -154,7 +154,7 @@ class FileType(object):
 
     @property
     def default_name(self):
-        return ".".join([self.base_name, self.ext])
+        return self.base_name # ".".join([self.base_name, self.ext])
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -200,6 +200,8 @@ class FileTypes(object):
     TXT = FileType(to_file_ns('txt'), 'file', 'txt', MimeTypes.TXT)
     # Generic Log file
     LOG = FileType(to_file_ns('log'), 'file', 'log', MimeTypes.TXT)
+    # Config file
+    CFG = FileType(to_file_ns('cfg'), 'config', 'cfg', MimeTypes.TXT)
 
     # THIS NEEDS TO BE CONSISTENT with scala code. When the datastore
     # is written to disk the file type id's might be translated to

--- a/pbcommand/models/tool_contract.py
+++ b/pbcommand/models/tool_contract.py
@@ -7,7 +7,7 @@ import abc
 
 import pbcommand
 
-from .common import TaskTypes, ResourceTypes
+from .common import TaskTypes, ResourceTypes, REGISTERED_FILE_TYPES
 
 __version__ = pbcommand.get_version()
 
@@ -48,6 +48,12 @@ def validate_tool_contract(tc):
     """
     __validate_ioputs("Inputs must have at least 1 input.", tc.task.input_file_types)
     __validate_ioputs("Outputs must have at least 1 output", tc.task.output_file_types)
+    for oft in tc.task.output_file_types:
+        file_type = REGISTERED_FILE_TYPES[oft.file_type_id]
+        if oft.default_name.endswith(file_type.ext):
+            raise ValueError(
+                "File {i} default name already has extension: {n}".format(
+                i=oft.label, n=oft.default_name))
     return tc
 
 

--- a/pbcommand/resolver.py
+++ b/pbcommand/resolver.py
@@ -84,14 +84,7 @@ def _resolve_output_file(registry_d, file_type, output_file_type, root_output_di
 
     # FIXME. THIS NEED TO BE FUNDAMENTALLY FIXED and updated to use the spec
     # in the avro schema.
-    if isinstance(output_file_type.default_name, basestring):
-        a, b = os.path.splitext(output_file_type.default_name)
-        return _get_fname(a, b.replace('.', ''))
-    elif isinstance(output_file_type.default_name, (list, tuple)):
-        base, ext = output_file_type.default_name
-        return _get_fname(base, ext)
-    else:
-        return _get_fname(file_type.base_name, file_type.ext)
+    return _get_fname(output_file_type.default_name, file_type.ext)
 
 
 def _resolve_resource_types(resources, output_dir, root_tmp_dir):

--- a/tests/data/dev_example_dev_txt_app_tool_contract.json
+++ b/tests/data/dev_example_dev_txt_app_tool_contract.json
@@ -43,7 +43,7 @@
             {
                 "title": "Txt outfile", 
                 "description": "Generic Output Txt file", 
-                "default_name": "output.txt", 
+                "default_name": "output", 
                 "id": "txt_out", 
                 "file_type_id": "PacBio.FileTypes.txt"
             }

--- a/tests/data/dev_example_tool_contract.json
+++ b/tests/data/dev_example_tool_contract.json
@@ -43,7 +43,7 @@
             {
                 "title": "Filtered Fasta file", 
                 "description": "Filtered Fasta file", 
-                "default_name": "filter.fasta", 
+                "default_name": "filter", 
                 "id": "fasta_out", 
                 "file_type_id": "PacBio.FileTypes.Fasta"
             }

--- a/tests/data/dev_gather_fasta_app_tool_contract.json
+++ b/tests/data/dev_gather_fasta_app_tool_contract.json
@@ -15,7 +15,7 @@
             {
                 "title": "Chunk JSON", 
                 "description": "Output Fasta", 
-                "default_name": "gathered.fasta", 
+                "default_name": "gathered", 
                 "id": "output", 
                 "file_type_id": "PacBio.FileTypes.Fasta"
             }

--- a/tests/data/dev_scatter_fasta_app_tool_contract.json
+++ b/tests/data/dev_scatter_fasta_app_tool_contract.json
@@ -39,7 +39,7 @@
             {
                 "title": "Chunk JSON", 
                 "description": "Scattered/Chunked Fasta Chunk.json", 
-                "default_name": "fasta.chunks.json", 
+                "default_name": "fasta.chunks", 
                 "id": "cjson", 
                 "file_type_id": "PacBio.FileTypes.CHUNK"
             }

--- a/tests/data/pbcommand.tasks.dev_fastq2fasta_tool_contract.json
+++ b/tests/data/pbcommand.tasks.dev_fastq2fasta_tool_contract.json
@@ -20,7 +20,7 @@
         "nproc": 1, 
         "output_types": [
             {
-                "default_name": "file.fasta", 
+                "default_name": "file", 
                 "description": "description for <FileType id=PacBio.FileTypes.Fasta name=file.fasta >", 
                 "file_type_id": "PacBio.FileTypes.Fasta", 
                 "id": "Label PacBio.FileTypes.Fasta_0", 

--- a/tests/data/pbcommand.tasks.dev_qhello_world_tool_contract.json
+++ b/tests/data/pbcommand.tasks.dev_qhello_world_tool_contract.json
@@ -20,7 +20,7 @@
         "nproc": 1, 
         "output_types": [
             {
-                "default_name": "file.fasta", 
+                "default_name": "file", 
                 "description": "description for <FileType id=PacBio.FileTypes.Fasta name=file.fasta >", 
                 "file_type_id": "PacBio.FileTypes.Fasta", 
                 "id": "Label PacBio.FileTypes.Fasta_0", 

--- a/tests/data/pbcommand.tasks.dev_txt_custom_outs_tool_contract.json
+++ b/tests/data/pbcommand.tasks.dev_txt_custom_outs_tool_contract.json
@@ -20,14 +20,14 @@
         "nproc": 1, 
         "output_types": [
             {
-                "default_name": "PacBio.FileTypes.txt_file_0.txt", 
+                "default_name": "PacBio.FileTypes.txt_file_0", 
                 "description": "File <FileType id=PacBio.FileTypes.txt name=file.txt >", 
                 "file_type_id": "PacBio.FileTypes.txt", 
                 "id": "label_PacBio.FileTypes.txt", 
                 "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
             }, 
             {
-                "default_name": "PacBio.FileTypes.txt_file_1.txt", 
+                "default_name": "PacBio.FileTypes.txt_file_1", 
                 "description": "File <FileType id=PacBio.FileTypes.txt name=file.txt >", 
                 "file_type_id": "PacBio.FileTypes.txt", 
                 "id": "label_PacBio.FileTypes.txt", 

--- a/tests/data/pbcommand.tasks.dev_txt_hello_tool_contract.json
+++ b/tests/data/pbcommand.tasks.dev_txt_hello_tool_contract.json
@@ -20,14 +20,14 @@
         "nproc": 3, 
         "output_types": [
             {
-                "default_name": "file.txt", 
+                "default_name": "file", 
                 "description": "description for <FileType id=PacBio.FileTypes.txt name=file.txt >", 
                 "file_type_id": "PacBio.FileTypes.txt", 
                 "id": "Label PacBio.FileTypes.txt_0", 
                 "title": "<FileType id=PacBio.FileTypes.txt name=file.txt >"
             }, 
             {
-                "default_name": "file.txt", 
+                "default_name": "file", 
                 "description": "description for <FileType id=PacBio.FileTypes.txt name=file.txt >", 
                 "file_type_id": "PacBio.FileTypes.txt", 
                 "id": "Label PacBio.FileTypes.txt_1", 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -31,7 +31,7 @@ class TestParsers(unittest.TestCase):
             file_id="gff",
             name="GFF file",
             description="GFF file description",
-            default_name="annotations.gff")
+            default_name="annotations")
         tc_contract = p.to_contract()
         d = tc_contract.to_dict()
         inputs = d['tool_contract']['input_types']
@@ -54,7 +54,7 @@ class TestParsers(unittest.TestCase):
             {
                 'title': 'GFF file',
                 'description': 'GFF file description',
-                'default_name': 'annotations.gff',
+                'default_name': 'annotations',
                 'id': 'gff',
                 'file_type_id': 'PacBio.FileTypes.gff'
             }
@@ -88,6 +88,22 @@ class TestParsers(unittest.TestCase):
 
         opts2 = pa([])
         self.assertFalse(opts2.loud)
+
+    def test_catch_output_file_extension(self):
+        p = get_pbparser(
+            "pbcommand.tasks.test_parsers",
+            "0.1.0",
+            "Tool Name",
+            "Tool Descripion",
+            "pbcommand-driver-exe ")
+        p.add_output_file_type(
+            file_type=FileTypes.GFF,
+            file_id="gff",
+            name="GFF file",
+            description="GFF file description",
+            default_name="annotations.gff")
+        tc = p.to_contract()
+        self.assertRaises(ValueError, tc.to_dict)
 
     # TODO we should add a lot more tests for parser behavior
 


### PR DESCRIPTION
@mpkocher I decided against half-measures; emitting a tool contract will fail if an output file default_name includes the expected extension.  (This won't guard against incorrect extensions, unfortunately, but downstream stuff shouldn't break if these slip in.)
