### PR TITLE
incrementing version number because PyPI sucks

### DIFF
--- a/pbcommand/__init__.py
+++ b/pbcommand/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 3, 20)
+VERSION = (0, 3, 21)
 
 
 def get_version():


### PR DESCRIPTION
I got HTTP 500 from the server trying to upload the 0.3.20 tarball, and it wouldn't let me replace it with the same filename, so...
