### PR TITLE
also check for dataset in list when skipping import

### DIFF
--- a/pbcommand/services/service_access_layer.py
+++ b/pbcommand/services/service_access_layer.py
@@ -423,7 +423,7 @@ class ServiceAccessLayer(object):
             file_type = FileTypes.ALL()[dataset_meta_type.metatype]
             ds_endpoint = _get_endpoint_or_raise(file_type)
             datasets = self._get_datasets_by_type(ds_endpoint)
-            uuids = set([ds['uuid'] for ds in datasets])
+            uuids = {ds['uuid'] for ds in datasets}
             if not dataset_meta_type.uuid in uuids:
                  raise JobExeError(("Dataset {u} was imported but does not "+
                                     "appear in the dataset list; this may "+

--- a/pbcommand/services/service_access_layer.py
+++ b/pbcommand/services/service_access_layer.py
@@ -419,6 +419,16 @@ class ServiceAccessLayer(object):
         :rtype: JobResult
         """
         dataset_meta_type = get_dataset_metadata(path)
+        def _verify_dataset_in_list():
+            file_type = FileTypes.ALL()[dataset_meta_type.metatype]
+            ds_endpoint = _get_endpoint_or_raise(file_type)
+            datasets = self._get_datasets_by_type(ds_endpoint)
+            uuids = set([ds['uuid'] for ds in datasets])
+            if not dataset_meta_type.uuid in uuids:
+                 raise JobExeError(("Dataset {u} was imported but does not "+
+                                    "appear in the dataset list; this may "+
+                                    "indicate XML schema errors.").format(
+                                    u=dataset_meta_type.uuid))
         result = self.get_dataset_by_uuid(dataset_meta_type.uuid)
         if result is None:
             log.info("Importing dataset {p}".format(p=path))
@@ -432,18 +442,11 @@ class ServiceAccessLayer(object):
                                    "XML schema errors.").format(
                                    u=dataset_meta_type.uuid))
             # validation 2: make sure it shows up in the listing
-            file_type = FileTypes.ALL()[dataset_meta_type.metatype]
-            ds_endpoint = _get_endpoint_or_raise(file_type)
-            datasets = self._get_datasets_by_type(ds_endpoint)
-            uuids = set([ds['uuid'] for ds in datasets])
-            if not dataset_meta_type.uuid in uuids:
-                 raise JobExeError(("Dataset {u} was imported but does not "+
-                                    "appear in the subread list; this may "+
-                                    "indicate XML schema errors.").format(
-                                    u=dataset_meta_type.uuid))
+            _verify_dataset_in_list()
             return job_result
         else:
             log.info("{f} already imported. Skipping importing. {r}".format(r=result, f=dataset_meta_type.metatype))
+            _verify_dataset_in_list()
             # need to clean this up
             return JobResult(self.get_job_by_id(result['jobId']), 0, "")
 


### PR DESCRIPTION
The problem with my first try is that re-running an import that failed might appear to succeed if the dataset can at least be retrieved by UUID.
