### PR TITLE
use streaming parser to retrieve dataset metatype and UUID

### DIFF
--- a/pbcommand/utils.py
+++ b/pbcommand/utils.py
@@ -430,9 +430,11 @@ def get_dataset_metadata(path):
     :param path:
     :return:
     """
-    f = ET.parse(path).getroot().attrib
-    mt = f['MetaType']
-    uuid = f['UniqueId']
+    uuid = mt = None
+    for event, element in ET.iterparse(path, events=("start",)):
+        uuid = element.get("UniqueId")
+        mt = element.get("MetaType")
+        break
     if mt in FileTypes.ALL_DATASET_TYPES().keys():
         return DataSetMetaData(uuid, mt)
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
 import functools
+import tempfile
 import unittest
 import argparse
 import logging
 
-from pbcommand.utils import Singleton, compose, get_parsed_args_log_level
+from pbcommand.utils import (Singleton, compose, get_parsed_args_log_level,
+    get_dataset_metadata)
 
 
 class TestSingleton(unittest.TestCase):
@@ -91,3 +93,20 @@ class TestLogging(unittest.TestCase):
         p = _get_argparser(logging.NOTSET).parse_args([])
         l = get_parsed_args_log_level(p)
         self.assertEqual(l, logging.NOTSET)
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_dataset_metadata(self):
+        try:
+            import pbcore.io
+            import pbcore.data
+        except ImportError:
+            raise unittest.SkipTest("pbcore not available, skipping")
+        else:
+            ds = pbcore.io.SubreadSet(pbcore.data.getUnalignedBam())
+            ds_file = tempfile.NamedTemporaryFile(suffix=".subreadset.xml").name
+            ds.write(ds_file)
+            md = get_dataset_metadata(ds_file)
+            self.assertEqual(md.metatype, "PacBio.DataSet.SubreadSet")
+            self.assertEqual(md.uuid, ds.uuid)


### PR DESCRIPTION
@mpkocher I don't know how to unify this with the pbcore functionality without introducing a dependency in either direction.  but here at least is a version that is more consistent with pbcore and avoids parsing the entire file.
