### PR TITLE
Add relative path support to ReseqConditions

### DIFF
--- a/pbcommand/pb_io/conditions.py
+++ b/pbcommand/pb_io/conditions.py
@@ -1,6 +1,30 @@
 import json
+import os
 
-from pbcommand.models import ReseqConditions
+from pbcommand.models import ReseqConditions, ReseqCondition
+
+
+def _resolve_conditions(cs, path):
+    """
+    :type cs: ReseqConditions
+    :rtype: ReseqConditions
+    """
+
+    def _resolve_if(p):
+        if os.path.isabs(p):
+            return p
+        else:
+            return os.path.join(path, p)
+
+    rconditions = []
+    for c in cs.conditions:
+        s = _resolve_if(c.subreadset)
+        a = _resolve_if(c.alignmentset)
+        r = _resolve_if(c.referenceset)
+        rc = ReseqCondition(c.cond_id, s, a, r)
+        rconditions.append(rc)
+
+    return cs._replace(conditions=rconditions)
 
 
 def load_reseq_conditions_from(json_file_or_dict):
@@ -12,11 +36,18 @@ def load_reseq_conditions_from(json_file_or_dict):
     :rtype: ReseqConditions
     """
 
-    # refactor that common useage from TC io
+    # refactor that common usage from TC io
     if isinstance(json_file_or_dict, dict):
         d = json_file_or_dict
     else:
         with open(json_file_or_dict, 'r') as f:
             d = json.loads(f.read())
 
-    return ReseqConditions.from_dict(d)
+    cs = ReseqConditions.from_dict(d)
+
+    # Resolve
+    if isinstance(json_file_or_dict, basestring):
+        dir_name = os.path.dirname(os.path.abspath(json_file_or_dict))
+        return _resolve_conditions(cs, dir_name)
+    else:
+        return cs

--- a/tests/data/example-conditions/reseq-conditions-02.json
+++ b/tests/data/example-conditions/reseq-conditions-02.json
@@ -11,7 +11,7 @@
       "condId": "cond_alpha",
       "subreadset": "subreadset-02.xml",
       "alignmentset": "alignmentset-B.xml",
-      "referenceset": "/path/to/reference.xml"
+      "referenceset": "reference.xml"
     },
     {
       "condId": "cond_beta",

--- a/tests/data/example-conditions/reseq-conditions-02.json
+++ b/tests/data/example-conditions/reseq-conditions-02.json
@@ -1,0 +1,24 @@
+{
+  "_condition_doc": "Example of a 'Resequencing' Condition Type with Files that have relative paths",
+  "conditions": [
+    {
+      "condId": "cond_alpha",
+      "subreadset": "subreadset-01.xml",
+      "alignmentset": "alignmentset-A.xml",
+      "referenceset": "reference.xml"
+    },
+    {
+      "condId": "cond_alpha",
+      "subreadset": "subreadset-02.xml",
+      "alignmentset": "alignmentset-B.xml",
+      "referenceset": "/path/to/reference.xml"
+    },
+    {
+      "condId": "cond_beta",
+      "subreadset": "subreadset-03.xml",
+      "alignmentset": "alignmentset-C.xml",
+      "referenceset": "reference.xml"
+    }
+  ],
+  "pipelineId": "pbsmrtpipe.pipelines.my_pipeline"
+}

--- a/tests/test_pb_io_conditions.py
+++ b/tests/test_pb_io_conditions.py
@@ -1,5 +1,6 @@
 import unittest
 import logging
+import os
 
 from base_utils import get_data_file_from_subdir
 
@@ -21,10 +22,11 @@ def _loader(name):
 
 class TestSerializationOfResequencingConditions(unittest.TestCase):
 
+    FILE_NAME = 'reseq-conditions-01.json'
+
     @classmethod
     def setUpClass(cls):
-        name = 'reseq-conditions-01.json'
-        cls.cs = _loader(name)
+        cls.cs = _loader(cls.FILE_NAME)
 
     def test_condition_n(self):
         self.assertEqual(len(self.cs.conditions), 3)
@@ -32,3 +34,16 @@ class TestSerializationOfResequencingConditions(unittest.TestCase):
     def test_condition_a(self):
         log.info(self.cs)
         self.assertEqual(self.cs.conditions[0].cond_id, "cond_alpha")
+
+    def test_condition_paths_abs(self):
+        for c in self.cs.conditions:
+            self.assertTrue(os.path.isabs(c.subreadset))
+            self.assertTrue(os.path.isabs(c.alignmentset))
+            self.assertTrue(os.path.isabs(c.referenceset))
+            print "XXX", c
+
+
+class TestSerializationOfResequencingConditionsWithRelativePath(TestSerializationOfResequencingConditions):
+
+    FILE_NAME = 'reseq-conditions-02.json'
+

--- a/tests/test_pb_io_conditions.py
+++ b/tests/test_pb_io_conditions.py
@@ -40,7 +40,6 @@ class TestSerializationOfResequencingConditions(unittest.TestCase):
             self.assertTrue(os.path.isabs(c.subreadset))
             self.assertTrue(os.path.isabs(c.alignmentset))
             self.assertTrue(os.path.isabs(c.referenceset))
-            print "XXX", c
 
 
 class TestSerializationOfResequencingConditionsWithRelativePath(TestSerializationOfResequencingConditions):


### PR DESCRIPTION
Use the same model as the ExternalResources in PacBioDataSet. SubreadSet, AlignmentSet, ReferenceSet path in ReseqCondition can be provided as a relative path to the reseq-condition.json file.
