### PR TITLE
tool contract option resolver bug fix

### DIFF
--- a/pbcommand/cli/examples/dev_mixed_app.py
+++ b/pbcommand/cli/examples/dev_mixed_app.py
@@ -53,6 +53,8 @@ def add_rtc_options(p):
     p.add_input_file_type(FileTypes.CSV, "csv", "Input CSV", "Input csv description")
     p.add_output_file_type(FileTypes.REPORT, "rpt", "Output Report", "Output PacBio Report JSON", "example.report")
     p.add_int("pbcommand.task_options.alpha", "alpha", 25, "Alpha", "Alpha description")
+    p.add_float("pbcommand.task_options.beta", "beta", 1.234, "Beta", "Beta description")
+    p.add_boolean("pbcommand.task_options.gamma", "gamma", True, "Gamma", "Gamma description")
     return p
 
 
@@ -65,7 +67,7 @@ def add_argparse_only(p):
     :return:
     """
     p.add_argument("--output-h5", type=str, help="Optional output H5 file.")
-    p.add_argument("--beta", type=int, default=1234, help="Example option")
+    p.add_argument("--epsilon", type=int, default=1234, help="Example option")
     return p
 
 
@@ -78,9 +80,12 @@ def get_contract_parser():
     return p
 
 
-def _fake_main(csv, report_json, alpha=1, beta=1234, output_h5=None):
-    _d = dict(c=csv, r=report_json, a=alpha, b=beta, h=output_h5)
-    log.info("Running main with {c} {r} alpha={a} beta={b} h5={h}".format(**_d))
+def _fake_main(csv, report_json, alpha=1, beta=1.234, gamma=True, epsilon=1234,
+               output_h5=None):
+    _d = dict(c=csv, r=report_json, a=alpha, b=beta, g=gamma, e=epsilon, h=output_h5)
+    log.info("Running main with {c} {r} alpha={a} beta={b} gamma={g} epsilon={e} h5={h}".format(**_d))
+    with open(report_json, "w") as f:
+        f.write("{}")
     return 0
 
 
@@ -90,7 +95,7 @@ def args_runner(args):
     csv = args.csv
     report_json = args.rpt
     output_h5 = args.output_h5
-    return _fake_main(csv, report_json, alpha=args.alpha, beta=args.beta, output_h5=output_h5)
+    return _fake_main(csv, report_json, alpha=args.alpha, beta=args.beta, gamma=args.gamma, epsilon=args.epsilon, output_h5=output_h5)
 
 
 def resolved_tool_contract_runner(rtc):
@@ -103,7 +108,9 @@ def resolved_tool_contract_runner(rtc):
     csv = rtc.task.input_files[0]
     rpt = rtc.task.output_files[0]
     alpha = rtc.task.options["pbcommand.task_options.alpha"]
-    return _fake_main(csv, rpt, alpha=alpha)
+    beta = rtc.task.options["pbcommand.task_options.beta"]
+    gamma = rtc.task.options["pbcommand.task_options.gamma"]
+    return _fake_main(csv, rpt, alpha=alpha, beta=beta, gamma=gamma)
 
 
 def main(argv=sys.argv):

--- a/pbcommand/resolver.py
+++ b/pbcommand/resolver.py
@@ -53,16 +53,18 @@ def _resolve_options(tool_contract, tool_options):
     # Get and Validate resolved value.
     # TODO. None support should be removed.
     for option in tool_contract.task.options:
-        for optid in option_ids:
-            exp_type = option['pb_option']['type']
-            value = tool_options.get(optid, option['pb_option']['default'])
+        optid = option['pb_option']['option_id']
+        exp_type = option['pb_option']['type']
+        value = tool_options.get(optid, option['pb_option']['default'])
 
-            if not isinstance(value, type_map[exp_type]):
-                raise ToolContractError("Incompatible option types. Supplied "
-                                        "{i}. Expected {t}".format(
-                                            i=type(value),
-                                            t=exp_type))
-            resolved_options[optid] = value
+        if not isinstance(value, type_map[exp_type]):
+            #assert False, option['pb_option']
+            raise ToolContractError("Incompatible option types for {o}. "
+                                    "Supplied {i}. Expected {t}".format(
+                                        o=optid,
+                                        i=type(value),
+                                        t=exp_type))
+        resolved_options[optid] = value
 
     return resolved_options
 

--- a/tests/test_e2e_example_apps.py
+++ b/tests/test_e2e_example_apps.py
@@ -51,3 +51,14 @@ class TestQuickCustomTxtCustomOuts(pbcommand.testkit.PbTestApp):
 
     REQUIRES_PBCORE = False
     INPUT_FILES = [get_data_file("example.txt")]
+
+
+class TestOptionTypes(pbcommand.testkit.PbTestApp):
+    DRIVER_BASE = "python -m pbcommand.cli.examples.dev_mixed_app"
+    REQUIRES_PBCORE = False
+    INPUT_FILES = [get_data_file("example.txt")]
+    TASK_OPTIONS = {
+        "pbcommand.task_options.alpha": 50,
+        "pbcommand.task_options.beta": 9.876,
+        "pbcommand.task_options.gamma": False
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,4 +105,10 @@ class TestUtils(unittest.TestCase):
         else:
             md = get_dataset_metadata(pbtestdata.get_file("subreads-xml"))
             self.assertEqual(md.metatype, "PacBio.DataSet.SubreadSet")
-            self.assertEqual(md.uuid, ds.uuid)
+            try:
+                from pbcore.io import SubreadSet
+            except ImportError:
+                raise unittest.SkipTest("pbcore not available, skipping")
+            else:
+                ds = SubreadSet(pbtestdata.get_file("subreads-xml"))
+                self.assertEqual(md.uuid, ds.uuid)


### PR DESCRIPTION
@mpkocher commit d79c9d50e7b8ce2806dcf14b5c471e2231df76da was broken - this fixes it and adds another test.  I'm not entirely sure if this is what you wanted to do with that change but the inner `for` loop looked unnecessary anyway.
